### PR TITLE
Ignore EXEC sys.sp_db_vardecimal_storage_format

### DIFF
--- a/sqlserver2pgsql.pl
+++ b/sqlserver2pgsql.pl
@@ -1800,6 +1800,11 @@ EOF
         {
             next;
         }
+        # Ignore EXEC sys.sp_db_vardecimal_storage_format, enabling for vardecimal storage format was only needed in SQL Server 2005 and means nothing for PG.
+        elsif ($line =~ /^EXEC sys\.sp_db_vardecimal_storage_format/)
+        {
+            next;
+        }
 
         # Still on views: there are empty lines, and C-style comments
         elsif ($line =~ /^\s*$/)


### PR DESCRIPTION
Enabling vardecimal storage format was only needed in SQL Server 2005
and means nothing for PostgreSQL.

See http://msdn.microsoft.com/en-us/library/bb326653.aspx