### PR TITLE
is_windows is incorrent because on MacOS $^O return darwin 

### DIFF
--- a/sqlserver2pgsql.pl
+++ b/sqlserver2pgsql.pl
@@ -454,7 +454,7 @@ sub next_col_pos
 # Test if we are on windows. We will have to convert / to \ in the XML files
 sub is_windows
 {
-    if ($^O =~ /win/i)
+    if ($^O =~ /^win/i)
     {
         return 1;
     }


### PR DESCRIPTION
and match the actual regexp.
I've restrict little more the regexp to match only windows