### PR TITLE
Added support for converting functions used as part of default constraints.

### DIFF
--- a/sqlserver2pgsql.pl
+++ b/sqlserver2pgsql.pl
@@ -404,7 +404,7 @@ sub convert_transactsql_code
 	$code =~ s/[\[\]]/\"/gi;
 	$code =~ s/getdate\s*\(\)/CURRENT_TIMESTAMP/gi;
 	$code =~ s/user_name\s*\(\)/CURRENT_USER/gi;
-	$code =~ s/datepart\s*\(\s*(.*)\s*\,\s*(.*)\s*\)/date_part('$1', $2)/gi;
+	$code =~ s/datepart\s*\(\s*(.*?)\s*\,\s*(.*?)\s*\)/date_part('$1', $2)/gi;
 	return $code;
 }
 

--- a/sqlserver2pgsql.pl
+++ b/sqlserver2pgsql.pl
@@ -401,7 +401,10 @@ sub format_identifier_cols_index
 sub convert_transactsql_code
 {
 	my ($code)=@_;
-	$code =~ s/getdate\s*\(\)/CURRENT_TIMESTAMP/g;
+	$code =~ s/[\[\]]/\"/gi;
+	$code =~ s/getdate\s*\(\)/CURRENT_TIMESTAMP/gi;
+	$code =~ s/user_name\s*\(\)/CURRENT_USER/gi;
+	$code =~ s/datepart\s*\(\s*(.*)\s*\,\s*(.*)\s*\)/date_part('$1', $2)/gi;
 	return $code;
 }
 


### PR DESCRIPTION
Added support for converting functions used as part of default constraints:
- user_name to CURRENT_USER.
- datepart to date_part and wrapping date part type in single quotes.
- Brakets to double quotes.

Also made regex matching case insensitive.