### PR TITLE
Some fixes

### DIFF
--- a/sqlserver2pgsql.pl
+++ b/sqlserver2pgsql.pl
@@ -101,7 +101,7 @@ sub parse_conf_file
     while (my $line = <CONF>)
     {
         $line =~ s/#.*//;        # Remove comments
-        $line =~ s/\s+=\s+//;    # Remove whitespaces around the =
+        $line =~ s/\s+=\s+/=/;    # Remove whitespaces around the =
         $line =~ s/\s+$//;       # Remove trailing whitespaces
         next
             if ($line =~ /^$/);  # Empty line after comments have been removed

--- a/sqlserver2pgsql.pl
+++ b/sqlserver2pgsql.pl
@@ -1853,7 +1853,7 @@ EOF
             }
             $constraint->{TYPE}  = 'CHECK';
             $constxt =~
-                s/\[(\S+)\]/$1/g; # We remove the []. And hope this will parse
+                s/\[(\S+?)\]/$1/g; # We remove the []. And hope this will parse
             $constraint->{TEXT} = $constxt;
             push @{$objects->{SCHEMAS}->{$schema}->{'TABLES'}->{$table}->{CONSTRAINTS}},
                 ($constraint);


### PR DESCRIPTION
PFA a PR with 2 commits:

* first one fix trivial issue in conf_file parsing (noticed while using the provided example file)
* second one fix substitution issue I saw with a real dump today. FTR, here's a test case to reproduce it:

```
ALTER TABLE [dbo].[foo]  WITH CHECK ADD  CONSTRAINT [CHECK_BAR] CHECK  (([DT_START]>[DT_BEGIN]))
```

was giving:
```
ALTER TABLE "foo" ADD CONSTRAINT "CHECK_BAR" CHECK (DT_START]>[DT_BEGIN);
```

now gives:
```
ALTER TABLE "foo" ADD CONSTRAINT "CHECK_BAR" CHECK (DT_START>DT_BEGIN);
```