### PR TITLE
Fix a bug in the generation of .ktr kettle job files for incremental data migration.

### DIFF
--- a/sqlserver2pgsql.pl
+++ b/sqlserver2pgsql.pl
@@ -392,13 +392,13 @@ sub postgres_convert_column
         'timestamp with time zone' => 'to_char({colname} AT TIME ZONE \'UTC\', \'YYYY-MM-DD HH:MI:SS.US+00\')');
     if (defined ($functions{$coltype}))
     {
-	my $tmpcol = $functions{$coltype};
-	$tmpcol =~ s/\{colname\}/"$colname"/;
+		my $tmpcol = $functions{$coltype};
+		$tmpcol =~ s/\{colname\}/$colname/;
         return $tmpcol;
     }
     else
     {
-        return "\"$colname\"";
+        return $colname;
     }
 }
 
@@ -821,7 +821,7 @@ sub generate_kettle
 
             {
                 my $coldef = sql_convert_column($col,$refschema->{TABLES}->{$table}->{COLS}->{$col}->{TYPE}) . " AS " . format_identifier($col);
-                my $pgcoldef = postgres_convert_column($col,$refschema->{TABLES}->{$table}->{COLS}->{$col}->{TYPE}) . " AS " . format_identifier($col);
+                my $pgcoldef = postgres_convert_column(format_identifier($col),$refschema->{TABLES}->{$table}->{COLS}->{$col}->{TYPE}) . " AS " . format_identifier($col);
                 push @colsdef,($coldef);
                 push @pgcolsdef,($pgcoldef);
             }


### PR DESCRIPTION
The problem appears when column names are in uppercase in the source database but lowercase in the postgres database. When preparing the sql statement reading the postgres table, one should call the format_identifier function (which itself calls the format_identifier function, which takes into account the value of the -keep_identifier_case parameter), instead of just putting double quotes around the column names.