### PR TITLE
Ignore GRANT statements

### DIFF
--- a/sqlserver2pgsql.pl
+++ b/sqlserver2pgsql.pl
@@ -2268,6 +2268,16 @@ EOF
             next;
         }
 
+        # Ignore grant statements
+        elsif ($line =~ /^GRANT ([^ ]+) ON (.+) TO \[[^ ]+\]/)
+        {
+            next;
+        }
+        elsif ($line =~ /^GRANT VIEW ([^ ]+) ON (.+) TO \[[^ ]+\]/)
+        {
+            next;
+        }
+
         elsif ($line =~ /^ALTER (ROLE|USER)/)
         {
             next;


### PR DESCRIPTION
This change ignores statements like the following in the script generated by SQL Server Management Studio
```sql
GRANT SELECT ON [dbo].[T_ParamValue] TO [WebUser] AS [dbo]
GRANT UPDATE ON [dbo].[T_ParamValue] TO [WebUser] AS [dbo]
GRANT VIEW DEFINITION ON [dbo].[V_MgrState] TO [Mgr_Config_Admin] AS [dbo]
```

I realize that we can prevent these from being included when the script is generated from SSMS, but I figured, we may as well ignore them too.