### PR TITLE
Add name map file

### DIFF
--- a/example_conf_file
+++ b/example_conf_file
@@ -26,12 +26,13 @@ parallelism_in=8 # Parallelism reading from SQL Server (where available) Default
 parallelism_out=8 # Default value is 8. Number of parallel connections used by kettle to insert data into the PostgreSQL database
 
 # Optional behaviour
-case insensitive=0 # set it to 1 to generate a dump with citext and check constraints all over the place
-no relabel dbo=1 # set it to 0 to convert the dbo schema to public
-convert numeric to int=1 # set it to 0 to keep numeric(xx,0) as numeric(xx,0). Will be converted to smallint, int or bigint by default
+case insensitive=0          # set it to 1 to generate a dump with citext and check constraints all over the place
+no relabel dbo=1            # set it to 0 to convert the dbo schema to public
+convert numeric to int=1    # set it to 0 to keep numeric(xx,0) as numeric(xx,0). Will be converted to smallint, int or bigint by default
 relabel schemas=dbo=>foo;schema1=>bar
-keep identifier case=1 # keep case of database objects
-validate constraints = yes # yes, after or no, should the constraints be validated by the dump ? (yes=validate during load, after after the load, no keep invalidated)
+keep identifier case=1      # keep case of database objects; comment out to convert names to lowercase
+#camelcasetosnake=1         # Uncomment to convert to snake case; comment out to leave names unchanged (or lowercase)
+validate constraints = yes  # yes, after or no, should the constraints be validated by the dump ? (yes=validate during load, after after the load, no keep invalidated)
 
 # Incremental job
 sort size=10000 # drives the amount of memory and temporary files that will be created by an incremental job

--- a/example_conf_file
+++ b/example_conf_file
@@ -6,6 +6,9 @@ before file=/tmp/before
 after file=/tmp/after
 unsure file=/tmp/unsure
 
+# File listing old and new column names, by table
+namemap file=/tmp/colnamemap
+
 kettle directory=/tmp/kettle # Comment this line if you don't want a kettle script to be generated
 # These are ignored as long as kettle is not set
 sql server database=foo

--- a/sqlserver2pgsql.pl
+++ b/sqlserver2pgsql.pl
@@ -41,6 +41,7 @@ our $kettle;
 our $before_file;
 our $after_file;
 our $unsure_file;
+our $namemap_file;
 our $case_treatment=1; # 1=convert to lowercase, 2=convert to snake_case, 0 do nothing
 our $ignore_errors;
 our $keep_identifier_case;
@@ -94,6 +95,7 @@ sub parse_conf_file
       'before file'              => 'before_file',
       'after file'               => 'after_file',
       'unsure file'              => 'unsure_file',
+      'namemap file'             => 'namemap_file',
       'sql server dump filename' => 'filename',
       'case insensitive'         => 'case_insensitive',
       'no relabel dbo'           => 'norelabel_dbo',
@@ -712,7 +714,7 @@ sub usage
 {
     print qq{
 Usage: 
-    sqlserver2pgsql.pl -b BEFORE_FILE -a AFTER_FILE -u UNSURE_FILE -f SQLSERVER_SCHEMA_FILE
+    sqlserver2pgsql.pl -b BEFORE_FILE -a AFTER_FILE -u UNSURE_FILE -f SQLSERVER_SCHEMA_FILE -map NAMEMAP_FILE
 
 Description:
 
@@ -737,6 +739,9 @@ Mandatory options:
     -u UNSURE_SCRIPT
             contains objects we attempt to migrate, but cannot guarantee, such 
             as views or complex indexes.
+
+    -map NAMEMAP_FILE
+            tab delimited text file with old and new column names, by table
 
 Options:
 
@@ -2393,12 +2398,17 @@ EOF
 # We generate alphabetically, to make things less random (this data comes from a hash)
 sub generate_schema
 {
-    my ($before_file, $after_file, $unsure_file) = @_;
+    my ($before_file, $after_file, $unsure_file, $namemap_file) = @_;
 
     # Open the output files (except kettle, we'll do that at the end)
     open BEFORE, ">:utf8", $before_file or die "Cannot open $before_file, $!";
     open AFTER,  ">:utf8", $after_file  or die "Cannot open $after_file, $!";
     open UNSURE, ">:utf8", $unsure_file or die "Cannot open $unsure_file, $!";
+    if ($namemap_file) 
+    {
+	    open NAMEMAP, ">:utf8", $namemap_file or die "Cannot open $namemap_file, $!";
+    }
+    
     print BEFORE "\\set ON_ERROR_STOP\n";
     print BEFORE "\\set ECHO all\n";
     print BEFORE "BEGIN;\n";
@@ -2409,6 +2419,11 @@ sub generate_schema
     print AFTER "\\set ECHO all\n";
     print UNSURE "BEGIN;\n";
 
+    if ($namemap_file) 
+    {
+        print NAMEMAP "Schema\tTable\tOldName\tNewName\n";
+    }
+    
     # Are we case insensitive ? We have to install citext then
     # Won't work on pre-9.1 database. But as this is a migration tool
     # if someone wants to start with an older version, it's their problem :)
@@ -2489,12 +2504,19 @@ sub generate_schema
 
             {
                 my $colref = $refschema->{TABLES}->{$table}->{COLS}->{$col};
-                my $coldef = format_identifier($col) . " " . $colref->{TYPE};
+                my $newcolname = format_identifier($col);
+                my $coldef = $newcolname . " " . $colref->{TYPE};
                 if ($colref->{NOT_NULL})
                 {
                     $coldef .= ' NOT NULL';
                 }
                 push @colsdef, ($coldef);
+                
+                if ($namemap_file) 
+                {
+                    print NAMEMAP $schema . "\t" . $table . "\t" . $col . "\t" . $newcolname . "\n";
+                }
+                    
             }
             print BEFORE "CREATE TABLE " . format_identifier($schema) . '.' . format_identifier($table) . "( \n\t"
                 . join(",\n\t", @colsdef)
@@ -2904,6 +2926,11 @@ sub generate_schema
     close AFTER;
     close UNSURE;
 
+    if ($namemap_file) 
+    {
+        close NAMEMAP;
+    }
+
 }
 
 # This sub tries to avoid naming conflicts:
@@ -3015,6 +3042,7 @@ my $options = GetOptions(
 	 "u=s"    => \$unsure_file,
 	 "h"      => \$help,
 	 "conf=s" => \$conf_file,
+	 "map=s"  => \$namemap_file,
 	 "sd=s"   => \$sd,
 	 "sh=s"   => \$sh,
 	 "si=s"   => \$si,
@@ -3058,6 +3086,11 @@ if ($conf_file)
 
 # Set default values for anything not set yet
 set_default_conf_values();
+
+if (not $namemap_file)
+{
+    $namemap_file = "";
+}
 
 # We have no before, after, or unsure
 if (   not $before_file
@@ -3109,7 +3142,7 @@ parse_dump();
 resolve_name_conflicts();
 
 # Create the 3 schema files for PostgreSQL
-generate_schema($before_file, $after_file, $unsure_file);
+generate_schema($before_file, $after_file, $unsure_file, $namemap_file);
 
 # If asked, create the kettle job
 if ($kettle and (defined $ENV{'HOME'} or defined $ENV{'USERPROFILE'}))

--- a/sqlserver2pgsql.pl
+++ b/sqlserver2pgsql.pl
@@ -2421,7 +2421,7 @@ sub generate_schema
 
     if ($namemap_file) 
     {
-        print NAMEMAP "Schema\tTable\tOldName\tNewName\n";
+        print NAMEMAP "SourceTable\tSourceName\tSchema\tNewTable\tNewName\n";
     }
     
     # Are we case insensitive ? We have to install citext then
@@ -2494,6 +2494,8 @@ sub generate_schema
         # The tables
         foreach my $table (sort keys %{$refschema->{TABLES}})
         {
+            my $newtablename = format_identifier($table);
+            
             my @colsdef;
             foreach my $col (
                 sort {
@@ -2514,11 +2516,11 @@ sub generate_schema
                 
                 if ($namemap_file) 
                 {
-                    print NAMEMAP $schema . "\t" . $table . "\t" . $col . "\t" . $newcolname . "\n";
+                    print NAMEMAP $table . "\t" . $col . "\t" . $schema . "\t" . $newtablename . "\t" . $newcolname . "\n";
                 }
                     
             }
-            print BEFORE "CREATE TABLE " . format_identifier($schema) . '.' . format_identifier($table) . "( \n\t"
+            print BEFORE "CREATE TABLE " . format_identifier($schema) . '.' . $newtablename . "( \n\t"
                 . join(",\n\t", @colsdef)
                 . ");\n\n";
         }


### PR DESCRIPTION
These commits add the option of creating a tab-delimited file that lists the old and new column names for each table.

Adds command line argument `-map` and conf file parameter `namemap file`; the file is not created if these are both missing.

When updating the example conf file, I added the missing `camelcasetosnake` option, but left it commented out