### PR TITLE
Add option to skip checking the maximum length of citext columns

### DIFF
--- a/example_conf_file
+++ b/example_conf_file
@@ -26,12 +26,13 @@ parallelism_in=8 # Parallelism reading from SQL Server (where available) Default
 parallelism_out=8 # Default value is 8. Number of parallel connections used by kettle to insert data into the PostgreSQL database
 
 # Optional behaviour
-case insensitive=0 # set it to 1 to generate a dump with citext and check constraints all over the place
-no relabel dbo=1 # set it to 0 to convert the dbo schema to public
-convert numeric to int=1 # set it to 0 to keep numeric(xx,0) as numeric(xx,0). Will be converted to smallint, int or bigint by default
+case insensitive=0          # set it to 1 to generate a dump with citext and check constraints all over the place
+no relabel dbo=1            # set it to 0 to convert the dbo schema to public
+convert numeric to int=1    # set it to 0 to keep numeric(xx,0) as numeric(xx,0). Will be converted to smallint, int or bigint by default
 relabel schemas=dbo=>foo;schema1=>bar
-keep identifier case=1 # keep case of database objects
-validate constraints = yes # yes, after or no, should the constraints be validated by the dump ? (yes=validate during load, after after the load, no keep invalidated)
+keep identifier case=1      # keep case of database objects; comment out to convert names to lowercase
+#camelcasetosnake=1         # Uncomment to convert to snake case; comment out to leave names unchanged (or lowercase)
+validate constraints = yes  # yes, after or no, should the constraints be validated by the dump ? (yes=validate during load, after after the load, no keep invalidated)
 
 # Incremental job
 sort size=10000 # drives the amount of memory and temporary files that will be created by an incremental job

--- a/example_conf_file
+++ b/example_conf_file
@@ -6,6 +6,9 @@ before file=/tmp/before
 after file=/tmp/after
 unsure file=/tmp/unsure
 
+# File listing old and new column names, by table
+namemap file=/tmp/colnamemap
+
 kettle directory=/tmp/kettle # Comment this line if you don't want a kettle script to be generated
 # These are ignored as long as kettle is not set
 sql server database=foo

--- a/sqlserver2pgsql.pl
+++ b/sqlserver2pgsql.pl
@@ -2268,6 +2268,16 @@ EOF
             next;
         }
 
+        # Ignore grant statements
+        elsif ($line =~ /^GRANT ([^ ]+) ON (.+) TO \[[^ ]+\]/)
+        {
+            next;
+        }
+        elsif ($line =~ /^GRANT VIEW ([^ ]+) ON (.+) TO \[[^ ]+\]/)
+        {
+            next;
+        }
+
         elsif ($line =~ /^ALTER (ROLE|USER)/)
         {
             next;


### PR DESCRIPTION
When I convert columns from varchar to citext, I don't want to check the length of every converted field.  This change adds option `skip citext length check` to the conf file.