### PR TITLE
Warn the user if a column or table name is more than 63 characters long

### DIFF
--- a/sqlserver2pgsql.pl
+++ b/sqlserver2pgsql.pl
@@ -485,6 +485,11 @@ sub format_identifier
     croak "identifier not defined in format_identifier" unless (defined $identifier);
     $identifier=rename_identifier($identifier);
 
+    if (length($identifier) > 63)
+    {
+        print STDERR "WARNING: $identifier is more than 63 characters long; PostgreSQL will truncate the name internally\n";
+    }
+    
     # Now, we protect the identifier (similar to quote_ident in PG)
     $identifier=~ s/"/""/g;
     $identifier='"'.$identifier.'"';


### PR DESCRIPTION
Table and Column names cannot be more than 63 characters long; this change checks for this